### PR TITLE
Fix udClient task bug in Release

### DIFF
--- a/Extension/udClient/task.json
+++ b/Extension/udClient/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": 0,
-        "Minor": 121,
+        "Minor": 122,
         "Patch": 0
     },
     "groups": [

--- a/Extension/udClient/udClient.ts
+++ b/Extension/udClient/udClient.ts
@@ -36,7 +36,7 @@ var workingDir = tl.getInput('workingDirectory', true);
 
 var udClientPath; // loaded below
 var udClientLocation = tl.getInput('udClientLocation');
-if (udClientLocation != tl.getVariable('build.sourcesDirectory')) {
+if (udClientLocation != tl.getVariable('System.DefaultWorkingDirectory')) {
     //custom tool location for udclient was specified
     tl.debug('udclient location specified explicitly by task: ' + udClientLocation);
     udClientPath = udClientLocation;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes Included
- Switched udclient [check on line 39](https://github.com/IBM-UrbanCode/vsts-urbancode-deploy/blob/master/Extension/udClient/udClient.ts#L39) to use `System.DefaultWorkingDirectory`
- Added an npm script `gulp` to eliminate the need for global install of the [gulp-cli module](https://www.npmjs.com/package/gulp-cli) - can now simply run `npm run gulp` to build/package

## Issues Addressed
- Closes #9 